### PR TITLE
Round not precision

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+This is a fork of [github.com/wbotelhos/rating](https://github.com/wbotelhos/rating). We were bumped into the bug that, when trying to rate a new item, we received the error:
+```
+PG::NumericValueOutOfRange: ERROR: numeric field overflow (ActiveRecord::RangeError)
+DETAIL: A field with precision 17, scale 14 must round to an absolute value less than 10^3.
+```
+Since our fields storing data were all set to precision 25 and scale 16, with no values stored in the database approaching 10, the assumption is that this had to be in the gem itself.
+
 # Rating
 
 [![Tests](https://github.com/wbotelhos/rating/workflows/Tests/badge.svg)](https://github.com/wbotelhos/rating/actions)

--- a/lib/rating/models/rating/rating.rb
+++ b/lib/rating/models/rating/rating.rb
@@ -24,10 +24,12 @@ module Rating
 
         values[:scopeable_type] = scopeable.class.base_class.name unless scopeable.nil?
 
+        total_count = total_count.to_f
+
         sql = %(
           SELECT
-            (CAST(#{total_count} AS DECIMAL(17, 14)) / #{distinct_count}) count_avg,
-            COALESCE(AVG(value), 0)                                       rating_avg
+          ROUND(#{total_count} / #{distinct_count}, 2) AS count_avg,
+          ROUND(COALESCE(AVG(value), 0), 2) AS rating_avg
           FROM #{rate_table_name}
           WHERE
             resource_type = :resource_type

--- a/lib/rating/version.rb
+++ b/lib/rating/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Rating
-  VERSION = '1.0.0'
+  VERSION = '1.0.1'
 end


### PR DESCRIPTION
First attempt at fixing the issue about precision being too low whenever a rating is attempted. 

```
PG::NumericValueOutOfRange: ERROR: numeric field overflow (ActiveRecord::RangeError)
DETAIL: A field with precision 17, scale 14 must round to an absolute value less than 10^3.
```